### PR TITLE
fix: Fix output of highlight data

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,12 @@ pub struct Alignoth {
     pub(crate) read_data_output: Option<PathBuf>,
 
     /// If present highlight data will be written to the given file path
-    #[structopt(long, parse(from_os_str), conflicts_with("output"), requires("highlight"))]
+    #[structopt(
+        long,
+        parse(from_os_str),
+        conflicts_with("output"),
+        requires("highlight")
+    )]
     pub(crate) highlight_data_output: Option<PathBuf>,
 
     /// If present, data and vega-lite specs of the generated plot will be split and written to the given directory

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,10 @@ pub struct Alignoth {
     #[structopt(long, parse(from_os_str), conflicts_with("output"))]
     pub(crate) read_data_output: Option<PathBuf>,
 
+    /// If present highlight data will be written to the given file path
+    #[structopt(long, parse(from_os_str), conflicts_with("output"), requires("highlight"))]
+    pub(crate) highlight_data_output: Option<PathBuf>,
+
     /// If present, data and vega-lite specs of the generated plot will be split and written to the given directory
     #[structopt(long, short = "o", parse(from_os_str))]
     pub(crate) output: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,6 @@ fn main() -> Result<()> {
         opt.region.start as f32 - 0.5,
         opt.region.end as f32 - 0.5
     ]);
-    if let Some(highlight) = opt.highlight {
-        plot_specs["datasets"]["highlight"] = json!(vec![highlight]);
-    }
     if let Some(out_path) = &opt.output {
         let bam_file_name = &opt
             .bam_path
@@ -49,6 +46,11 @@ fn main() -> Result<()> {
         ))
         .unwrap();
         reference_file.write_all(reference_data.to_string().as_bytes())?;
+        if let Some(highlight) = opt.highlight {
+            let mut highlight_file =
+                File::create(Path::join(out_path, format!("{bam_file_name}.highlight.json"))).unwrap();
+            highlight_file.write_all(json!(vec![highlight]).to_string().as_bytes())?;
+        }
     } else if let (Some(spec_output), Some(ref_data_output), Some(read_data_output)) = (
         &opt.spec_output,
         &opt.ref_data_output,
@@ -60,6 +62,10 @@ fn main() -> Result<()> {
         read_file.write_all(read_data.to_string().as_bytes())?;
         let mut reference_file = File::create(ref_data_output).unwrap();
         reference_file.write_all(reference_data.to_string().as_bytes())?;
+        if let (Some(highlight), Some(highlight_output)) = (opt.highlight, opt.highlight_data_output) {
+            let mut highlight_file = File::create(highlight_output).unwrap();
+            highlight_file.write_all(json!(vec![highlight]).to_string().as_bytes())?;
+        }
     } else {
         plot_specs["datasets"]["reference"] = reference_data;
         plot_specs["datasets"]["reads"] = read_data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,11 @@ fn main() -> Result<()> {
         .unwrap();
         reference_file.write_all(reference_data.to_string().as_bytes())?;
         if let Some(highlight) = opt.highlight {
-            let mut highlight_file =
-                File::create(Path::join(out_path, format!("{bam_file_name}.highlight.json"))).unwrap();
+            let mut highlight_file = File::create(Path::join(
+                out_path,
+                format!("{bam_file_name}.highlight.json"),
+            ))
+            .unwrap();
             highlight_file.write_all(json!(vec![highlight]).to_string().as_bytes())?;
         }
     } else if let (Some(spec_output), Some(ref_data_output), Some(read_data_output)) = (
@@ -62,7 +65,9 @@ fn main() -> Result<()> {
         read_file.write_all(read_data.to_string().as_bytes())?;
         let mut reference_file = File::create(ref_data_output).unwrap();
         reference_file.write_all(reference_data.to_string().as_bytes())?;
-        if let (Some(highlight), Some(highlight_output)) = (opt.highlight, opt.highlight_data_output) {
+        if let (Some(highlight), Some(highlight_output)) =
+            (opt.highlight, opt.highlight_data_output)
+        {
             let mut highlight_file = File::create(highlight_output).unwrap();
             highlight_file.write_all(json!(vec![highlight]).to_string().as_bytes())?;
         }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -324,7 +324,8 @@ impl PlotOrder for Vec<Read> {
             for (row, row_end) in row_ends.iter().enumerate().take(10000).skip(1) {
                 if min(read.position, read.mpos) > *row_end + 5
                     || (read.position <= 5 && *row_end == 0)  // Row is unfilled and read can be placed at the beginning without 5bp distance to the previous read
-                    || (read.mpos == -1 && read.position > *row_end + 5) // Read has no mate and can be placed purely dependent on its own position
+                    || (read.mpos == -1 && read.position > *row_end + 5)
+                // Read has no mate and can be placed purely dependent on its own position
                 {
                     read.set_row(row as u32);
                     row_ends[row] = max(read.end_position, read.mpos);

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -7,6 +7,7 @@ use rand::prelude::IteratorRandom;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rust_htslib::bam;
+use rust_htslib::bam::ext::BamRecordExtensions;
 use rust_htslib::bam::record::{Cigar, CigarStringView};
 use rust_htslib::bam::FetchDefinition::Region as FetchRegion;
 use rust_htslib::bam::Read as HtslibRead;
@@ -276,7 +277,7 @@ impl Read {
         let region = cli::Region {
             target: target.to_string(),
             start: record.pos() - record.cigar().leading_softclips(),
-            end: record.pos() + record.seq_len() as i64,
+            end: record.pos() + record.reference_end(),
         };
         let ref_seq = read_fasta(ref_path, &region)?;
         let read_seq = record
@@ -292,7 +293,7 @@ impl Read {
             flags: record.flags(),
             mapq: record.mapq(),
             row: None,
-            end_position: record.pos() + record.seq_len() as i64,
+            end_position: record.pos() + record.reference_end(),
             mpos: record.mpos(),
         })
     }
@@ -322,7 +323,8 @@ impl PlotOrder for Vec<Read> {
             }
             for (row, row_end) in row_ends.iter().enumerate().take(10000).skip(1) {
                 if min(read.position, read.mpos) > *row_end + 5
-                    || (read.position <= 5 && *row_end == 0)
+                    || (read.position <= 5 && *row_end == 0)  // Row is unfilled and read can be placed at the beginning without 5bp distance to the previous read
+                    || (read.mpos == -1 && read.position > *row_end + 5) // Read has no mate and can be placed purely dependent on its own position
                 {
                     read.set_row(row as u32);
                     row_ends[row] = max(read.end_position, read.mpos);


### PR DESCRIPTION
This PR fixes the outputting of the highlighting data that was written into the specs directly even when read and reference data was written into a separate file leading to an inconsistency. This fix adds a new option `--highlight-data-output` that lets the user specify a file path to output the highlight data similar to read and reference data. 