### PR TITLE
refactor: Use vega-lite to set plot height

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@ A tool for creating alignment plots from bam files. The generated [vega-lite](ht
 
 The following options are available when using bamboo:
 
-| argument         | short | explanation                                                                                                 | default |
-|------------------|-------|-------------------------------------------------------------------------------------------------------------|---------|
-| bam-path         | -b    | The bam file to be visualized.                                                                              |         |
-| reference        | -r    | The path to the reference fasta file                                                                        |         |
-| region           | -g    | Chromosome and region for the visualization. Example: 2:132424-132924                                       |         |
-| highlight        | -h    | Interval that will be highlighted in the visualization. Example: 132400-132500                              |         |
-| max-read-depth   | -d    | Set the maximum rows of reads that will be shown in the alignment plots                                     | 500     |
-| output           | -o    | If present, data and vega-lite specs of the generated plot will be split and written to the given directory |         |
-| data-format      | -f    | Sets the output format for the read, reference and highlight data                                           | json    |
-| spec-output      |       | If present vega-lite specs will be written to the given file path                                           |         |
-| read-data-output |       | If present read data will be written to the given file path                                                 |         |
-| ref-data-output  |       | If present reference data will be written to the given file path                                            |         |
+| argument              | short | explanation                                                                                                 | default |
+|-----------------------|-------|-------------------------------------------------------------------------------------------------------------|---------|
+| bam-path              | -b    | The bam file to be visualized.                                                                              |         |
+| reference             | -r    | The path to the reference fasta file                                                                        |         |
+| region                | -g    | Chromosome and region for the visualization. Example: 2:132424-132924                                       |         |
+| highlight             | -h    | Interval that will be highlighted in the visualization. Example: 132400-132500                              |         |
+| max-read-depth        | -d    | Set the maximum rows of reads that will be shown in the alignment plots                                     | 500     |
+| max-width             | -w    | Set the maximum width of the resulting alignment plot                                                       | 1024    |
+| output                | -o    | If present, data and vega-lite specs of the generated plot will be split and written to the given directory |         |
+| data-format           | -f    | Sets the output format for the read, reference and highlight data                                           | json    |
+| spec-output           |       | If present vega-lite specs will be written to the given file path                                           |         |
+| read-data-output      |       | If present read data will be written to the given file path                                                 |         |
+| ref-data-output       |       | If present reference data will be written to the given file path                                            |         |
+| highlight-data-output |       | If present highlight data will be written to the given file path                                            |         |
 
 ## Installation
 

--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "width": {"step": 5},
+    "height": {"step": 8},
     "resolve": {
         "scale": {
             "strokeWidth": "independent"

--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "width": {"step": 5},
     "height": {"step": 8},
     "resolve": {
         "scale": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,13 @@ use structopt::StructOpt;
 
 fn main() -> Result<()> {
     let opt = cli::Alignoth::from_args();
-    let (read_data, reference_data, plot_depth) = create_plot_data(
+    let (read_data, reference_data) = create_plot_data(
         &opt.bam_path,
         &opt.reference,
         &opt.region,
         opt.max_read_depth,
     )?;
     let mut plot_specs: Value = serde_json::from_str(include_str!("../resources/plot.vl.json"))?;
-    plot_specs["height"] = json!(8 + 8 * plot_depth);
     plot_specs["width"] = json!(min(opt.max_width, 5 * (opt.region.length())));
     plot_specs["encoding"]["x"]["scale"]["domain"] = json!(vec![
         opt.region.start as f32 - 0.5,

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -25,7 +25,7 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
     ref_path: P,
     region: &Region,
     max_read_depth: usize,
-) -> Result<(Vec<Read>, Reference, u32)> {
+) -> Result<(Vec<Read>, Reference)> {
     let mut bam = bam::IndexedReader::from_path(&bam_path)?;
     let tid = bam.header().tid(region.target.as_bytes()).unwrap() as i32;
     bam.fetch(FetchRegion(tid, region.start, region.end))?;
@@ -35,16 +35,11 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
         .map(|r| Read::from_record(r, &ref_path, &region.target).unwrap())
         .collect_vec();
     data.order(max_read_depth)?;
-    let read_depth = if data.is_empty() {
-        0
-    } else {
-        data.iter().map(|r| r.row.unwrap()).max().unwrap()
-    };
     let reference_data = Reference {
         start: region.start,
         reference: read_fasta(ref_path, region)?.iter().collect(),
     };
-    Ok((data, reference_data, read_depth))
+    Ok((data, reference_data))
 }
 
 /// Reads the given region from the given fasta file and returns it as a vec of the bases as chars

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -352,7 +352,6 @@ mod tests {
     };
     use itertools::Itertools;
     use rust_htslib::bam::record::{Cigar, CigarString, CigarStringView};
-    use serde_json::json;
     use std::str::FromStr;
 
     #[test]
@@ -593,7 +592,7 @@ mod tests {
             start: 0,
             end: 20,
         };
-        let (reads, reference, max_depth) =
+        let (reads, reference) =
             create_plot_data("tests/reads.bam", "tests/reference.fa", &region, 100).unwrap();
         let expected_reference = Reference {
             start: 0,
@@ -610,10 +609,8 @@ mod tests {
             mpos: 789264,
         };
         let expected_reads = vec![expected_read];
-        let expected_max_depth = json!(1_u32);
         assert_eq!(reference, expected_reference);
         assert_eq!(reads, expected_reads);
-        assert_eq!(max_depth, expected_max_depth);
     }
 
     #[test]


### PR DESCRIPTION
This PR makes use of the Vega-lite function to set width or height of a plot with something like `"height": {"step": 8}`. This also makes some Rust code redundant so it should increase the performance ever so slightly.
It also adds missing documentation for `--max-width`.