### PR TITLE
fix: Reverse map color scale

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -225,8 +225,8 @@
                     "type": "quantitative",
                     "scale": {
                         "domain": [
-                            60,
-                            0
+                            0,
+                            60
                         ],
                         "range": [
                             "#910000",


### PR DESCRIPTION
This PR should fix the somehow reversed color scale for the mapq borders.