### PR TITLE
fix: fix interval position

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The name alignoth is derived from the visualized **align**ments combined with th
 
 ```alignoth -b path/to/my.bam -r path/to/my/reference.fa -g chr1:200-300 > plot.vl.json```
 
-To directly generate a plot in svg, png or pdf format we advice using the [vega-cli](https://vega.github.io/vega/usage/#cli) package:
+To directly generate a plot in svg, png or pdf format we advice using the [vega-cli](https://vega.github.io/vega/usage/#cli) and [vega-lite-cli]( https://vega.github.io/vega-lite/usage/compile.html#cli) packages:
 
-```alignoth -b path/to/my.bam -r path/to/my/reference.fa -g chr1:200-300 | vg2pdf > plot.pdf```
+```alignoth -b path/to/my.bam -r path/to/my/reference.fa -g chr1:200-300 | vl2vg | vg2pdf > plot.pdf```
 
 To generate an interactive view within an html file use `--html` and capture the output to a file:
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -271,7 +271,7 @@ impl Read {
         let region = cli::Region {
             target: target.to_string(),
             start: record.pos() - record.cigar().leading_softclips(),
-            end: record.pos() + record.reference_end(),
+            end: record.reference_end() + record.cigar().trailing_softclips(),
         };
         let ref_seq = read_fasta(ref_path, &region)?;
         let read_seq = record


### PR DESCRIPTION
alignoth some times fails due to an invalid interval.
This is caused by a miscalculation.