### PR TITLE
fix: Improve error message on missing when bam header doesn't contain given target

### DIFF
--- a/src/plot.rs
+++ b/src/plot.rs
@@ -27,7 +27,14 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
     max_read_depth: usize,
 ) -> Result<(Vec<Read>, Reference)> {
     let mut bam = bam::IndexedReader::from_path(&bam_path)?;
-    let tid = bam.header().tid(region.target.as_bytes()).unwrap() as i32;
+    let tid = bam
+        .header()
+        .tid(region.target.as_bytes())
+        .context(format!(
+            "bam header does not contain given region target {}",
+            &region.target
+        ))
+        .unwrap() as i32;
     bam.fetch(FetchRegion(tid, region.start, region.end))?;
     let mut data = bam
         .records()


### PR DESCRIPTION
This PR fixes #58 by printing a proper error message instead of unwrapping the None value.