### PR TITLE
fix: Remove potential risk of unplaced reads for bam files with very high density

### DIFF
--- a/src/plot.rs
+++ b/src/plot.rs
@@ -339,7 +339,7 @@ impl PlotOrder for Vec<Read> {
                     row_ends[row] = max(read.end_position, read.mpos);
                     ordered_reads.insert(&read.name, row);
                     // We placed a read in the last row available so all rows seem to be filled so we append a new empty row for the next read
-                    if row == row_ends.len() {
+                    if row == row_ends.len() - 1 {
                         row_ends.push(0)
                     }
                     break;

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -338,7 +338,7 @@ impl PlotOrder for Vec<Read> {
                     read.set_row(row as u32);
                     row_ends[row] = max(read.end_position, read.mpos);
                     ordered_reads.insert(&read.name, row);
-                    // All rows seem to be filled so we append a new empty row for the next read
+                    // We placed a read in the last row available so all rows seem to be filled so we append a new empty row for the next read
                     if row == row_ends.len() {
                         row_ends.push(0)
                     }


### PR DESCRIPTION
This PR removes a potential risk of unplaced reads for bam files with very high density and fixes #61.