### PR TITLE
fix: Update htslib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "rust-htslib"
-version = "0.40.2"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b73defe4e69f22d0208eaeb004fc563e968588d13fe2aafc1aa6f19cb4808d4"
+checksum = "cb1c69e02791dab5cdcc63d80347e3f92974194cef06fd8b88bbca98789f9386"
 dependencies = [
  "bio-types",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 structopt = "0.3.26"
-rust-htslib = "0.40.2"
+rust-htslib = "0.41.0"
 bio = "1.1.0"
 log = "0.4.14"
 simplelog = "0.12.0"


### PR DESCRIPTION
This PR updates rust-htslib as alignoth fails for reads where softclips are cornered by hardclips. This is caused by a miscalculcation of leading/trailing softclips in rust-htslib and fixed in the latest version (see https://github.com/koesterlab/alignoth/issues/85).