### PR TITLE
fix: Reduce vertical mapq border size

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -189,11 +189,11 @@
                 },
                 {
                     "as": "start",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1, datum.position + datum.offset)"
+                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1.4, datum.position + datum.offset + 0.4)"
                 },
                 {
                     "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length + 1, datum.position + datum.offset + datum.length + 2)"
+                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length + 0.6, datum.position + datum.offset + datum.length + 1.6)"
                 }
             ],
             "mark": {


### PR DESCRIPTION
This PR reduces the vertical mapq border size that was half a base position before and is now smaller. If mapq was >= 60 and the border was therefore the same color as a fully matching read it was a bit confusing when viewing closely. 