### PR TITLE
fix: Remove end offset of 1

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -193,7 +193,7 @@
                 },
                 {
                     "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length + 0.6, datum.position + datum.offset + datum.length + 1.6)"
+                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length - 0.4, datum.position + datum.offset + datum.length + 0.6)"
                 }
             ],
             "mark": {
@@ -322,7 +322,7 @@
                 },
                 {
                     "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length + 1, datum.position + datum.offset + datum.length + 1.5)"
+                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length, datum.position + datum.offset + datum.length + 0.5)"
                 },
                 {
                     "filter": "datum.type != 'deletion'"
@@ -449,7 +449,7 @@
                 },
                 {
                     "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length + 1, datum.position + datum.offset + datum.length + 1.5)"
+                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length, datum.position + datum.offset + datum.length + 0.5)"
                 },
                 {
                     "filter": "datum.type == 'deletion'"


### PR DESCRIPTION
This PR fixes a bug where the end of a read was always 1 bp too long.