### PR TITLE
feat: Allow displaying user defined aux tags in read tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following options are available when using alignoth:
 | max-width             | -w    | Set the maximum width of the resulting alignment plot                                                                                                             | 1024    |
 | output                | -o    | If present, data and vega-lite specs of the generated plot will be split and written to the given directory                                                       |         |
 | data-format           | -f    | Sets the output format for the read, reference and highlight data                                                                                                 | json    |
-| aux_tags              | -x    | Displays the given content of the aux tags in the tooltip of the plot                                                                                             |         |
+| aux_tag               | -x    | Displays the given content of the aux tag in the tooltip of the plot. Multiple usage for more than one tag is possible.                                           |         |
 | spec-output           |       | If present vega-lite specs will be written to the given file path                                                                                                 |         |
 | read-data-output      |       | If present read data will be written to the given file path                                                                                                       |         |
 | ref-data-output       |       | If present reference data will be written to the given file path                                                                                                  |         |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following options are available when using alignoth:
 | max-width             | -w    | Set the maximum width of the resulting alignment plot                                                                                                             | 1024    |
 | output                | -o    | If present, data and vega-lite specs of the generated plot will be split and written to the given directory                                                       |         |
 | data-format           | -f    | Sets the output format for the read, reference and highlight data                                                                                                 | json    |
+| aux_tags              | -x    | Displays the given content of the aux tags in the tooltip of the plot                                                                                             |         |
 | spec-output           |       | If present vega-lite specs will be written to the given file path                                                                                                 |         |
 | read-data-output      |       | If present read data will be written to the given file path                                                                                                       |         |
 | ref-data-output       |       | If present reference data will be written to the given file path                                                                                                  |         |

--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -345,6 +345,9 @@
                     },
                     {
                         "field": "flags"
+                    },
+                    {
+                        "field": "aux"
                     }
                 ],
                 "strokeWidth": {
@@ -475,6 +478,9 @@
                     },
                     {
                         "field": "length"
+                    },
+                    {
+                        "field": "aux"
                     }
                 ],
                 "strokeWidth": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,10 @@ pub struct Alignoth {
     /// If present, the generated plot will inserted into a plain html file containing the plot centered which is then written to stdout
     #[structopt(long, conflicts_with("output"))]
     pub(crate) html: bool,
+
+    /// Displays the given content of the aux tags in the tooltip of the plot
+    #[structopt(long, short = "x")]
+    pub(crate) aux_tags: Option<Vec<String>>,
 }
 
 pub(crate) trait Preprocess {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,9 +82,9 @@ pub struct Alignoth {
     #[structopt(long, conflicts_with("output"))]
     pub(crate) html: bool,
 
-    /// Displays the given content of the aux tags in the tooltip of the plot
+    /// Displays the given content of the aux tags in the tooltip of the plot. Multiple usage for more than one tag is possible.
     #[structopt(long, short = "x")]
-    pub(crate) aux_tags: Option<Vec<String>>,
+    pub(crate) aux_tag: Option<Vec<String>>,
 }
 
 pub(crate) trait Preprocess {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         &opt.reference.as_ref().unwrap(),
         opt.region.as_ref().unwrap(),
         opt.max_read_depth,
-        opt.aux_tags,
+        opt.aux_tag,
     )?;
     let highlight = opt.highlight.map(|h| Interval {
         start: h.start - 0.5,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<()> {
         &opt.reference.as_ref().unwrap(),
         opt.region.as_ref().unwrap(),
         opt.max_read_depth,
+        opt.aux_tags,
     )?;
     let highlight = opt.highlight.map(|h| Interval {
         start: h.start - 0.5,

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -120,7 +120,10 @@ impl ToString for AuxRecord {
 }
 
 impl Serialize for AuxRecord {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         serializer.serialize_str(&self.to_string())
     }
 }
@@ -408,10 +411,12 @@ mod tests {
     use crate::create_plot_data;
     use crate::plot::CigarType::{Del, Ins, Match, Sub};
     use crate::plot::{
-        match_bases, read_fasta, CigarType, InnerPlotCigar, PlotCigar, PlotOrder, Read, Reference,
+        match_bases, read_fasta, AuxRecord, CigarType, InnerPlotCigar, PlotCigar, PlotOrder, Read,
+        Reference,
     };
     use itertools::Itertools;
     use rust_htslib::bam::record::{Cigar, CigarString, CigarStringView};
+    use std::collections::HashMap;
     use std::str::FromStr;
 
     #[test]
@@ -463,7 +468,7 @@ mod tests {
             row: None,
             end_position: 120,
             mpos: 100,
-            aux: vec![],
+            aux: AuxRecord(HashMap::new()),
         };
 
         let read2 = Read {
@@ -475,7 +480,7 @@ mod tests {
             row: None,
             end_position: 140,
             mpos: 120,
-            aux: vec![],
+            aux: AuxRecord(HashMap::new()),
         };
 
         let mut reads = vec![read1, read2];
@@ -494,7 +499,7 @@ mod tests {
             row: None,
             end_position: 120,
             mpos: 100,
-            aux: vec![],
+            aux: AuxRecord(HashMap::new()),
         };
 
         let read2 = Read {
@@ -506,6 +511,7 @@ mod tests {
             row: None,
             end_position: 140,
             mpos: 120,
+            aux: AuxRecord(HashMap::new()),
         };
 
         let read3 = Read {
@@ -517,6 +523,7 @@ mod tests {
             row: None,
             end_position: 150,
             mpos: 140,
+            aux: AuxRecord(HashMap::new()),
         };
 
         let mut reads = vec![read1, read2, read3];
@@ -576,7 +583,7 @@ mod tests {
             ),
             end_position: 887,
             mpos: 333,
-            aux: vec![],
+            aux: AuxRecord(HashMap::new()),
         };
 
         assert!(reads.contains(&expected_read));
@@ -709,6 +716,7 @@ mod tests {
             row: Some(1),
             end_position: 106,
             mpos: 789264,
+            aux: AuxRecord(HashMap::new()),
         };
         let expected_reads = vec![expected_read];
         assert_eq!(reference, expected_reference);

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -415,6 +415,7 @@ mod tests {
         Reference,
     };
     use itertools::Itertools;
+    use rust_htslib::bam;
     use rust_htslib::bam::record::{Cigar, CigarString, CigarStringView};
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -749,5 +750,14 @@ mod tests {
             },
         ]);
         assert_eq!(plot_cigar, expected_plot_cigar);
+    }
+
+    // Write test for AuxRecord
+    #[test]
+    fn test_empty_aux_record() {
+        let record = bam::Record::new();
+        let aux_record = AuxRecord::new(&record, &None);
+        let expected_aux_record = AuxRecord(HashMap::new());
+        assert_eq!(aux_record, expected_aux_record);
     }
 }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -115,7 +115,7 @@ impl ToString for AuxRecord {
         self.0
             .iter()
             .map(|(k, v)| format!("{}: {}", k, v))
-            .join("\n")
+            .join(", ")
     }
 }
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -416,7 +416,7 @@ mod tests {
     };
     use itertools::Itertools;
     use rust_htslib::bam;
-    use rust_htslib::bam::record::{Cigar, CigarString, CigarStringView};
+    use rust_htslib::bam::record::{Aux, Cigar, CigarString, CigarStringView};
     use std::collections::HashMap;
     use std::str::FromStr;
 
@@ -752,12 +752,35 @@ mod tests {
         assert_eq!(plot_cigar, expected_plot_cigar);
     }
 
-    // Write test for AuxRecord
     #[test]
     fn test_empty_aux_record() {
         let record = bam::Record::new();
         let aux_record = AuxRecord::new(&record, &None);
         let expected_aux_record = AuxRecord(HashMap::new());
         assert_eq!(aux_record, expected_aux_record);
+    }
+
+    #[test]
+    fn test_aux_record() {
+        let mut record = bam::Record::new();
+        let aux_integer_field = Aux::I32(1234);
+        record.push_aux(b"XI", aux_integer_field).unwrap();
+        let aux_record = AuxRecord::new(&record, &Some(vec!["XI".to_string()]));
+        let expected_aux_record = AuxRecord(HashMap::from_iter(vec![(
+            "XI".to_string(),
+            "1234".to_string(),
+        )]));
+        assert_eq!(aux_record, expected_aux_record);
+    }
+
+    #[test]
+    fn test_aux_record_to_string() {
+        let mut record = bam::Record::new();
+        let aux_integer_field = Aux::I32(1234);
+        record.push_aux(b"XI", aux_integer_field).unwrap();
+        let aux_record = AuxRecord::new(&record, &Some(vec!["XI".to_string()]));
+        let aux_record_string = aux_record.to_string();
+        let expected_aux_record_string = "XI: 1234".to_string();
+        assert_eq!(aux_record_string, expected_aux_record_string);
     }
 }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -115,7 +115,7 @@ impl ToString for AuxRecord {
         self.0
             .iter()
             .map(|(k, v)| format!("{}: {}", k, v))
-            .join(", ")
+            .join("\n")
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bio::io::fasta;
+use itertools::Itertools;
 use std::fs;
 use std::path::PathBuf;
 
@@ -41,6 +42,30 @@ pub(crate) fn get_fasta_length(fasta_path: &PathBuf, target: &str) -> Result<usi
     fasta_reader.fetch_all(target)?;
     fasta_reader.read(&mut seq)?;
     Ok(seq.len())
+}
+
+/// Takes any given aux and returns a string representation of it.
+pub(crate) fn aux_to_string(aux: rust_htslib::bam::record::Aux) -> String {
+    match aux {
+        rust_htslib::bam::record::Aux::Char(c) => String::from_utf8(vec![c]).unwrap(),
+        rust_htslib::bam::record::Aux::I8(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U8(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::I16(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U16(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::I32(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::U32(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::Float(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::Double(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::String(s) => s.to_owned(),
+        rust_htslib::bam::record::Aux::HexByteArray(i) => i.to_string(),
+        rust_htslib::bam::record::Aux::ArrayI8(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU8(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU16(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayI16(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayU32(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayI32(a) => a.iter().join(","),
+        rust_htslib::bam::record::Aux::ArrayFloat(a) => a.iter().join(","),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR allows the user to add one or more aux tags with `-x` or `--aux-tag` that will then be displayed in the tooltip of each read.