### PR TITLE
fix: Remove unconnected lines for unpaired reads

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -255,6 +255,9 @@
             },
             "transform": [
                 {
+                    "filter": "datum.mpos >= 0"
+                },
+                {
                     "as": "start",
                     "calculate": "if(datum.position < datum.mpos, datum.position + 0.5, datum.mpos + 0.5)"
                 },

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -294,6 +294,11 @@ impl Read {
             .iter()
             .map(|u| char::from(*u))
             .collect_vec();
+        let mpos = if record.is_paired() {
+            record.mpos()
+        } else {
+            -1
+        };
         Ok(Read {
             name: String::from_utf8(record.qname().to_vec())?,
             cigar: PlotCigar::from_cigar(record.cigar(), read_seq, ref_seq)?,
@@ -302,7 +307,7 @@ impl Read {
             mapq: record.mapq(),
             row: None,
             end_position: record.pos() + record.reference_end(),
-            mpos: record.mpos(),
+            mpos,
         })
     }
 


### PR DESCRIPTION
This PR removes unconnected lines for unpaired reads by checking `is_paired()`, setting `mpos` to `-1` if false and then filtering the read data for the lines of the plot for positive `mpos` values.