### PR TITLE
feat: Allow single selection of a read

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -207,7 +207,7 @@
             "encoding": {
                 "opacity": {
                     "condition": {"param": "rplc", "value": 1},
-                    "value": 0.1
+                    "value": 0.2
                 },
                 "strokeWidth": {
                     "field": "type",
@@ -278,7 +278,7 @@
             "encoding": {
                 "opacity": {
                     "condition": {"param": "rplc", "value": 1},
-                    "value": 0.1
+                    "value": 0.2
                 },
                 "strokeWidth": {
                     "value": 1
@@ -361,7 +361,7 @@
                 ],
                 "opacity": {
                     "condition": {"param": "rplc", "value": 1},
-                    "value": 0.1
+                    "value": 0.2
                 },
                 "strokeWidth": {
                     "field": "type",
@@ -495,7 +495,7 @@
                 ],
                 "opacity": {
                     "condition": {"param": "rplc", "value": 1},
-                    "value": 0.1
+                    "value": 0.2
                 },
                 "strokeWidth": {
                     "field": "type",

--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -200,7 +200,15 @@
                 "type": "rule",
                 "clip": true
             },
+            "params": [{
+                "name": "rplc",
+                "select": {"type": "point", "toggle": false}
+            }],
             "encoding": {
+                "opacity": {
+                    "condition": {"param": "rplc", "value": 1},
+                    "value": 0.1
+                },
                 "strokeWidth": {
                     "field": "type",
                     "scale": {
@@ -268,6 +276,10 @@
                 "clip": true
             },
             "encoding": {
+                "opacity": {
+                    "condition": {"param": "rplc", "value": 1},
+                    "value": 0.1
+                },
                 "strokeWidth": {
                     "value": 1
                 },
@@ -347,6 +359,10 @@
                         "field": "flags"
                     }
                 ],
+                "opacity": {
+                    "condition": {"param": "rplc", "value": 1},
+                    "value": 0.1
+                },
                 "strokeWidth": {
                     "field": "type",
                     "scale": {
@@ -477,6 +493,10 @@
                         "field": "length"
                     }
                 ],
+                "opacity": {
+                    "condition": {"param": "rplc", "value": 1},
+                    "value": 0.1
+                },
                 "strokeWidth": {
                     "field": "type",
                     "scale": {


### PR DESCRIPTION
This PR allows the user to highlight single reads for presentations by reducing the other reads opacity when a single read is clicked. This closes #75.

<img width="1223" alt="Bildschirmfoto 2023-10-04 um 13 10 21" src="https://github.com/koesterlab/alignoth/assets/39430842/9e38422c-2315-400d-9b28-ebb59a999783">
